### PR TITLE
Add -s option to swap haptic and rumble channels

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 Copyright (c) 2015-2016 Pila
-Copyright (c) 2022-2026 Crazy, AAGaming
+Copyright (c) 2022-2026 Crazy, AAGaming, Pixel1001
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Songs ready to play can be found in the original guy's [personal collection](htt
 	  -e 	Direct velocity to gain control, the MIDI file will set the gain"
 	  -t	(Steam Controller 2026 Only) Only use trackpads
 	  -b	(Steam Controller 2026 Only) Map first two channels to rumble instead of trackpads
-		-s	(Steam Controller 2026 Only) Swap channel mapping between haptics and rumble
+	  -s	(Steam Controller 2026 Only) Swap channel mapping between haptics and rumble
 
 ### MIDI files tips:
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Songs ready to play can be found in the original guy's [personal collection](htt
 	  -e 	Direct velocity to gain control, the MIDI file will set the gain"
 	  -t	(Steam Controller 2026 Only) Only use trackpads
 	  -b	(Steam Controller 2026 Only) Map first two channels to rumble instead of trackpads
+		-s	(Steam Controller 2026 Only) Swap channel mapping between haptics and rumble
 
 ### MIDI files tips:
 

--- a/main.cpp
+++ b/main.cpp
@@ -38,6 +38,7 @@ bool legacyInst = false;
 bool directVel = false;
 bool tritonTrackpad = false;
 bool tritonRumble = false;
+bool tritonSwap = false;
 int channelCount = 2;
 
 enum class ControllerType {
@@ -270,7 +271,7 @@ void playSong(SteamControllerInfos* controller,const ParamsStruct params){
 	MidiFile_t midifile;
 
 	//Open Midi File
-	midifile = MidiFile_load(params.midiSong);
+	midifile = MidiFile_load((char*)params.midiSong);
 
 	if(midifile == NULL){
 		cout << "Unable to open MIDI file!" << params.midiSong << endl;
@@ -342,7 +343,8 @@ void playSong(SteamControllerInfos* controller,const ParamsStruct params){
 		//Now play the last events found
 		for(int currentChannel = 0 ; currentChannel < channelCount ; currentChannel++){
 			MidiFileEvent_t selectedEvent = eventsToPlay[currentChannel];
-
+			int channelToPlay = currentChannel;
+			if (tritonSwap && channelCount == 4) channelToPlay = currentChannel ^ 2;
 			//If no note event available on the channel, skip it
 			if(!MidiFileEvent_isNoteStartEvent(selectedEvent) && !MidiFileEvent_isNoteEndEvent(selectedEvent)) continue;
 
@@ -351,15 +353,15 @@ void playSong(SteamControllerInfos* controller,const ParamsStruct params){
 			int8_t eventVel  = 0;
 			if(MidiFileEvent_isNoteStartEvent(selectedEvent)){
 				//Send note stop before playing to prevent Steam Controller (2026) rebooting when using motors
-				SteamHaptics_PlayNote(controller,currentChannel,NOTE_STOP,0);
+				SteamHaptics_PlayNote(controller,channelToPlay,NOTE_STOP,0);
 				eventNote = MidiFileNoteStartEvent_getNote(selectedEvent);
 				eventVel  = MidiFileNoteStartEvent_getVelocity(selectedEvent);
 			}
 
 			//Play notes
-			SteamHaptics_PlayNote(controller,currentChannel,eventNote,eventVel);
+			SteamHaptics_PlayNote(controller,channelToPlay,eventNote,eventVel);
 
-			displayPlayedNotes(currentChannel,eventNote);
+			displayPlayedNotes(channelToPlay,eventNote);
 		}
 	}
 
@@ -372,7 +374,7 @@ void playSong(SteamControllerInfos* controller,const ParamsStruct params){
 
 bool parseArguments(int argc, char** argv, ParamsStruct* params){
 	int c;
-	while ( (c = getopt(argc, argv, "di:petb")) != -1) {
+	while ( (c = getopt(argc, argv, "di:petbs")) != -1) {
 		unsigned long int value;
 		switch(c){
 		/*case 'l':
@@ -412,6 +414,9 @@ bool parseArguments(int argc, char** argv, ParamsStruct* params){
 		case 'b':
 			tritonRumble = true;
 			channelCount = 2;
+			break;
+		case 's':
+			tritonSwap = true;
 			break;
 		// case 'y':
 		// 	legacyInst = true;
@@ -467,6 +472,7 @@ int main(int argc, char** argv)
 			  "\n  -e 	Direct velocity to gain control, the MIDI file will set the gain"
 			  "\n  -t	(Steam Controller 2026 Only) Only use trackpads"
 			  "\n  -b	(Steam Controller 2026 Only) Map first two channels to rumble instead of trackpads"
+				"\n  -s	(Steam Controller 2026 Only) Swap channel mapping between haptics and rumble"
 				"" << endl;
 		return 1;
 	}


### PR DESCRIPTION
Hi,
I just wanted to add this as a feature as, for some midi files, they may sound better if the haptic and rumble channels are swapped, especially as the rumble is a lot louder than the trackpad haptics. Which could be done with -b but unlike -b, all 4 channels are still available

Thanks for the amazing project :D